### PR TITLE
rectifs css tuile ecoll et header

### DIFF
--- a/Front/app/base/header/tpl-header.html
+++ b/Front/app/base/header/tpl-header.html
@@ -23,16 +23,16 @@
 				<span>|</span>
 			</li>
 			<li>
-				<a href="#">
+				<span>
 					<span><%= language %></span>
-				</a>
+				</span>
 			</li>
 			<li>
 				<span>|</span>
 			</li>
 			<li>
 				<a id="logout" class="ripplelink"> 
-					<span data-i18n="header.logout">logout&nbsp;</span>
+					<span data-i18n="header.logout">logout &nbsp;</span>
 					<i class="glyphicon glyphicon-log-out"></i>
 				</a>
 			</li>

--- a/Front/app/styles/base/_header.less
+++ b/Front/app/styles/base/_header.less
@@ -26,6 +26,9 @@ header{
 			background: @header-hover;
 		}
 	}
+	.nav li span span {
+		padding: 0px 15px;
+	}
 	.navbar-brand{
 		i{
 			padding: 5px;

--- a/Front/app/styles/ui/_tile.less
+++ b/Front/app/styles/ui/_tile.less
@@ -110,7 +110,7 @@
 .track-dev,.track-faucon,.track-ganga,.track-macq,.track-oedic,.track-other,.track-undu{
 	background: @track;
 }
-.ecoll-bota, .ecoll-entomo, .ecoll-veto{
+.ecoll-bota, .ecoll-entomo, .ecoll-veto, .ecoll{
 	background: @ecoll;
 }
 .thesaurus{


### PR DESCRIPTION
* Le thème ecollection ne pouvait être affecté à la tuile uniquement si l'instance de l'appli était précisée dans la class (ex: .ecoll-entomo) maintenant cela prend en compte la classe .ecoll seule.
* Dans le header, lors du hover sur la langue, le comportement était le même que pour les boutons, alors que la langue n'est pas cliquable. Désormais rien ne se passe au hover, afin de ne pas induire l'utilisateur en erreur.