### PR TITLE
pyodbc version issue fix

### DIFF
--- a/Back/setup.py
+++ b/Back/setup.py
@@ -19,7 +19,7 @@ requires = [
     'zope.sqlalchemy',
     'waitress',
     'webtest',
-    'pyodbc',
+    'pyodbc==4.0.27',
     'sqlalchemy',
     'pyramid_jwt',
     'pyramid_jwtauth',


### PR DESCRIPTION
latest version of pyodbc (4.0.28) returns a [DLL load failed](https://github.com/mkleehammer/pyodbc/issues/663) when importing pyodbc.